### PR TITLE
Migrate to Yarn

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,6 +2,7 @@ version: 2.1
 orbs:
   docker: circleci/docker@0.5.19
   helm-tools: pennlabs/helm-tools@0.1.7
+  react-tools: pennlabs/react-tools@0.0.5
 
 branch-filters: &branch-filters
   filters:
@@ -9,36 +10,14 @@ branch-filters: &branch-filters
       only:
         - master
 
-jobs:
-  test:
-    working_directory: ~/pennlabs
-    docker:
-      - image: circleci/node:10
-    steps:
-      - checkout
-      - restore_cache:
-          key: dependency-cache-{{ checksum "package-lock.json" }}
-      - run:
-          name: Install dependencies
-          command: |
-            npm install
-      - save_cache:
-          key: dependency-cache-{{ checksum "package-lock.json" }}
-          paths:
-            - ./node_modules
-      - run:
-          name: Lint
-          command: |
-            npm run lint
-
 workflows:
   version: 2
   build-and-deploy:
     jobs:
-      - test
+      - react-tools/check
       - docker/publish:
           requires:
-            - test
+            - react-tools/check
           cache_from: "pennlabs/image-name:latest"
           image: pennlabs/image-name
           tag: "${CIRCLE_SHA1},latest"

--- a/.dockerignore
+++ b/.dockerignore
@@ -11,5 +11,5 @@ Dockerfile
 LICENSE
 
 # Misc
-.node_modules/
+node_modules/
 .next/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,19 +1,23 @@
-FROM node:10-buster
+FROM node:10-buster-slim
 
 LABEL maintainer="Penn Labs"
 
 WORKDIR /app/
 
 # Copy project dependencies
-COPY package*.json /app/
+COPY package.json /app/
+COPY yarn.lock /app/
 
 # Install project dependencies
-RUN npm install --production=true
+RUN yarn install --frozen-lockfile --production
+
+# Disable telemetry back to zeit
+ENV NEXT_TELEMETRY_DISABLED=1
 
 # Copy project files
 COPY . /app/
 
 # Build project
-RUN npm run build
+RUN yarn build
 
-CMD ["npm", "start"]
+CMD ["yarn", "start"]

--- a/k8s/values.yaml
+++ b/k8s/values.yaml
@@ -1,4 +1,4 @@
-deploy_version: 0.1.8
+deploy_version: 0.1.15
 image_tag: latest
 
 applications:


### PR DESCRIPTION
This PR migrates the template to use yarn, the react-tools orb, and contains misc fixes

[ch1591]
[ch1197]